### PR TITLE
One powerline-run.sh script add TERM not tested on ubuntu

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -2,4 +2,4 @@
 
 ln -s ~/.vim/.tmux.conf ~/.tmux.conf
 
-echo ". ~/.vim/powerline-run.sh" >> ~/.bashrc
+echo ". ~/.vim/powerline-run.sh" >> ~/.bash_profile

--- a/powerline-run.sh
+++ b/powerline-run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash 
+export TERM="xterm-256color"
+
 
 powerline-daemon -q
 POWERLINE_BASH_CONTINUATION=1


### PR DESCRIPTION
Add TERM to powerline-run.sh not to directly to bashrc and bash_profile
When we start powerline-run.sh it will run all neccesary change
- this is beta test