### PR TITLE
Add mouse scrooling buffer and showcmd

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -3,8 +3,15 @@ run-shell "powerline-daemon -q"
 source "/usr/local/lib/python2.7/dist-packages/powerline/bindings/tmux/powerline.conf"
 source "/usr/lib/python2.6/site-packages/powerline/bindings/tmux/powerline.conf"
 
-bind-key          - split-window
-bind-key          \ split-window -h
+#bind-key          - split-window
+#bind-key          \ split-window -h
 
-set -g mode-mouse off
-
+set -g mouse on
+bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
+bind -n WheelDownPane select-pane -t= \; send-keys -M
+bind -n C-WheelUpPane select-pane -t= \; copy-mode -e \; send-keys -M
+bind -t vi-copy    C-WheelUpPane   halfpage-up
+bind -t vi-copy    C-WheelDownPane halfpage-down
+bind -t emacs-copy C-WheelUpPane   halfpage-up
+bind -t emacs-copy C-WheelDownPane halfpage-down
+set -g @scroll-speed-num-lines-per-scroll 5 

--- a/.vimrc
+++ b/.vimrc
@@ -194,3 +194,5 @@ let g:ctrlp_custom_ignore = {
 
 " search the nearest ancestor that contains .git, .hg, .svn
 let g:ctrlp_working_path_mode = 2
+
+set showcmd


### PR DESCRIPTION
Mouse scrool in 2.1 tmux had some issue,
we can now mouse scrool up and copy in emacs mode clicking

Showcmd will show function like ,html